### PR TITLE
Bugfix - Add text chunking to Opus translations

### DIFF
--- a/src/api/opus_api.py
+++ b/src/api/opus_api.py
@@ -1,4 +1,6 @@
 import pandas as pd
+from langchain_core.documents import Document
+from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from src.api.i_translate_api import ITranslateAPI
 from src.client.opus_client import OpusClient
@@ -12,6 +14,12 @@ class OpusAPI(ITranslateAPI):
         for to_language in to_languages:
             self.models[to_language] = OpusClient(from_language=from_language, to_language=to_language)
 
+        self.text_splitter = RecursiveCharacterTextSplitter(
+            chunk_size=512,
+            chunk_overlap=20,
+            length_function=len,
+        )
+
     def translate(self, row: pd.DataFrame, column_names: [str]) -> {str: [pd.DataFrame]}:
         result = {str: [pd.DataFrame]}
         for to_language in self.to_languages:
@@ -20,8 +28,20 @@ class OpusAPI(ITranslateAPI):
         for to_language in self.to_languages:
             for col_index, column_name in enumerate(column_names):
                 original_text = row.iloc[col_index]
-                translation = self.models[to_language].translate(original_text) if original_text != '' else original_text
+                translation = self._translate(original_text, to_language) if original_text != '' else original_text
                 result[to_language].at[0, f'{self.from_language}-{column_name}'] = original_text
                 result[to_language].at[0, f'{to_language}-{column_name}'] = translation
 
         return result
+
+    def _translate(self, text: str, to_language: str) -> str:
+        result = ""
+        chunks = self._get_chunks(text)
+        for chunk in chunks:
+            translated_chunk = self.models[to_language].translate(chunk)
+            result += translated_chunk
+        return result
+
+    def _get_chunks(self, text) -> [str]:
+        chunks: [Document] = self.text_splitter.create_documents([text])
+        return [chunk.page_content for chunk in chunks]


### PR DESCRIPTION
### Notes:
* Add text chunking to Opus.

### Description:
* Integrate Langchain [RecursiveCharacterTextSplitter](https://api.python.langchain.com/en/latest/character/langchain_text_splitters.character.RecursiveCharacterTextSplitter.html#langchain_text_splitters.character.RecursiveCharacterTextSplitter.create_documents). This allows us to set a chunk size of 512.

### Why?
* Opus currently supports text size of 512 characters. 
* This was causing the following to throw running translations:

```
Token indices sequence length is longer than the specified maximum sequence length for this model (515 > 512). Running this sequence through the model will result in indexing errors
```

### Testing:
* Reran the failed translation.