### PR TITLE
Added azure chunking

### DIFF
--- a/src/api/translation/azure_translate_api.py
+++ b/src/api/translation/azure_translate_api.py
@@ -11,19 +11,25 @@ class AzureTranslateAPI(ITranslateAPI):
     def __init__(self, from_language: str, to_languages: List[str], key: str, region: str):
         super().__init__(from_language, to_languages)
         self.client = AzureTranslationClient(key, region)
+        self.MAX_CHARS = 50000
 
     def translate(
         self, batch: pd.DataFrame, column_names: List[str]
     ) -> Dict[str, pd.DataFrame]:
         result = {}
         flattened_content, positions = self._flatten_dataframe(batch, column_names)
-        response: List[TranslatedTextItem] = self.client.translate(
-            flattened_content, self.from_language, self.to_languages
-        )
-
+        chunks = self._split_into_chunks(flattened_content)
+        
+        all_responses: List[TranslatedTextItem] = []
+        for chunk in chunks:
+            chunk_response: List[TranslatedTextItem] = self.client.translate(
+                chunk, self.from_language, self.to_languages
+            )
+            all_responses.extend(chunk_response)
+        
+        language_indices = {lang: idx for idx, lang in enumerate(self.to_languages)}
         for to_language in self.to_languages:
-            translations = [item.translations[self.to_languages.index(to_language)].text for item in response]
-
+            translations = [item.translations[language_indices[to_language]].text for item in all_responses]
             translation_data = TranslationResult(
                 column_names=column_names,
                 positions=positions,
@@ -32,8 +38,27 @@ class AzureTranslateAPI(ITranslateAPI):
                 from_language=self.from_language,
                 to_language=to_language
             )
-
             translated_df = self._reconstruct_dataframe(translation_data)
             result[to_language] = translated_df
 
         return result
+    
+    def _split_into_chunks(self, texts: List[str]) -> List[List[str]]:
+        chunks = []
+        current_chunk = []
+        current_chunk_length = 0
+
+        for text in texts:
+            will_exceed_limit = current_chunk_length + len(text) > self.MAX_CHARS
+            if will_exceed_limit:
+                if current_chunk:  # Only append non-empty chunks
+                    chunks.append(current_chunk)
+                current_chunk = []
+                current_chunk_length = 0
+            current_chunk.append(text)
+            current_chunk_length += len(text)
+
+        if current_chunk:
+            chunks.append(current_chunk)
+
+        return chunks

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,6 @@ from typing import Dict
 from tqdm import tqdm
 import logging
 
-
 # Add the parent directory of `src` to the Python path
 current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.abspath(os.path.join(current_dir, os.pardir))


### PR DESCRIPTION
Azure translate has a maximum request size of 50k characters. This was causing errors where some batches we're throwing errors. We fix this by breaking up batches which are longer than 50k characters into sub-lists, we send each sub-list to Azure, and then recombine the results into a single list before reconstructing the dataframe.