### PR TITLE
Chunk batches to remain within open source limits

### DIFF
--- a/.env
+++ b/.env
@@ -25,3 +25,4 @@ LLM=
 CONDITIONS=code,min_chars
 MIN_CHAR_LENGTH=
 RESULT_UPLOADER_API=hf_result_uploader_api
+CHUNK_SIZE=

--- a/SDL.yaml
+++ b/SDL.yaml
@@ -24,6 +24,7 @@ services:
       - CONDITIONS=code,min_chars
       - MIN_CHAR_LENGTH=512
       - RESULT_UPLOADER_API=hf_result_uploader_api
+      - CHUNK_SIZE=
 profiles:
   compute:
     translate-en-af:

--- a/src/api/translation/builder/meta_translate_api_builder.py
+++ b/src/api/translation/builder/meta_translate_api_builder.py
@@ -11,5 +11,6 @@ class MetaTranslateAPIBuilder(IBuilder):
         if not self._instance:
             from_language = env.get_value(EnvVar.FromLanguage.value)
             to_languages = env.get_value(EnvVar.ToLanguages.value)
-            self._instance = MetaTranslateAPI(from_language, to_languages)
+            chunk_size = env.get_value(EnvVar.ChunkSize.value)
+            self._instance = MetaTranslateAPI(from_language, to_languages, int(chunk_size))
         return self._instance

--- a/src/api/translation/builder/opus_translate_api_builder.py
+++ b/src/api/translation/builder/opus_translate_api_builder.py
@@ -11,5 +11,6 @@ class OpusTranslateAPIBuilder(IBuilder):
         if not self._instance:
             from_language = env.get_value(EnvVar.FromLanguage.value)
             to_languages = env.get_value(EnvVar.ToLanguages.value)
-            self._instance = OpusTranslateAPI(from_language, to_languages)
+            chunk_size = env.get_value(EnvVar.ChunkSize.value)
+            self._instance = OpusTranslateAPI(from_language, to_languages, int(chunk_size))
         return self._instance

--- a/src/api/translation/open_source/meta_translate_api.py
+++ b/src/api/translation/open_source/meta_translate_api.py
@@ -5,8 +5,8 @@ from typing import List
 
 class MetaTranslateAPI(OpenSourceTranslateAPI):
 
-    def __init__(self, from_language: str, to_languages: List[str]):
-        super().__init__(from_language, to_languages)
+    def __init__(self, from_language: str, to_languages: List[str], chunk_size: int):
+        super().__init__(from_language, to_languages, chunk_size)
         self.client: MetaClient = MetaClient()
 
     def _translate(self, batch: List[str], to_language: str) -> List[str]:

--- a/src/api/translation/open_source/open_source_translate_api.py
+++ b/src/api/translation/open_source/open_source_translate_api.py
@@ -1,22 +1,47 @@
 from typing import List, Dict
 import pandas as pd
+from langchain_core.documents import Document
+from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from src.api.translation.i_translate_api import ITranslateAPI
 from src.api.translation.translation_result import TranslationResult
 
 
+def _combine_translation_chunks(translations: List[str], lengths: List[int]):
+    combined_translations = []
+    running_index = 0
+    for length in lengths:
+        translation_chunks = translations[running_index: running_index+length]
+        combined_translations.append(''.join(translation_chunks))
+        running_index += length
+    return combined_translations
+
+
 class OpenSourceTranslateAPI(ITranslateAPI):
-    def __init__(self, from_language: str, to_languages: List[str]):
+    def __init__(self, from_language: str, to_languages: List[str], chunk_size: int):
         super().__init__(from_language, to_languages)
+        self.text_splitter = RecursiveCharacterTextSplitter(
+            chunk_size=chunk_size,
+            chunk_overlap=20,
+            length_function=len,
+        )
 
     def translate(
             self, batch: pd.DataFrame, column_names: List[str]
     ) -> Dict[str, pd.DataFrame]:
         result = {}
         flattened_content, positions = self._flatten_dataframe(batch, column_names)
+        lengths: List[int] = []
+        chunks: List[str] = []
+        for chunk in flattened_content:
+            _chunks = self._get_chunks(chunk)
+            lengths.append(len(_chunks))
+            chunks.extend(_chunks)
 
         for to_language in self.to_languages:
-            translations = self._translate(flattened_content, to_language)
+            translated_chunks = self._translate(chunks, to_language)
+            translations = _combine_translation_chunks(translated_chunks, lengths)
+
             translation_data = TranslationResult(
                 column_names=column_names,
                 positions=positions,
@@ -30,6 +55,10 @@ class OpenSourceTranslateAPI(ITranslateAPI):
             result[to_language] = translated_df
 
         return result
+
+    def _get_chunks(self, text) -> [str]:
+        chunks: [Document] = self.text_splitter.create_documents([text])
+        return [chunk.page_content for chunk in chunks]
 
     def _translate(self, batch: List[str], to_language: str) -> List[str]:
         raise NotImplementedError

--- a/src/api/translation/open_source/opus_translate_api.py
+++ b/src/api/translation/open_source/opus_translate_api.py
@@ -5,8 +5,8 @@ from typing import Dict, List
 
 class OpusTranslateAPI(OpenSourceTranslateAPI):
 
-    def __init__(self, from_language: str, to_languages: List[str]):
-        super().__init__(from_language, to_languages)
+    def __init__(self, from_language: str, to_languages: List[str], chunk_size: int):
+        super().__init__(from_language, to_languages, chunk_size)
         self.models: Dict[str, OpusClient] = {}
         for to_language in to_languages:
             self.models[to_language] = OpusClient(

--- a/src/environment/i_environment.py
+++ b/src/environment/i_environment.py
@@ -42,3 +42,4 @@ class EnvVar(Enum):
     Conditions = "CONDITIONS"
     MinCharLength = "MIN_CHAR_LENGTH"
     ResultUploaderAPI = "RESULT_UPLOADER_API"
+    ChunkSize = "CHUNK_SIZE"

--- a/tst/api/open_source_translate_api_test.py
+++ b/tst/api/open_source_translate_api_test.py
@@ -1,0 +1,72 @@
+import unittest
+from typing import List
+
+import pandas as pd
+
+from src.api.translation.open_source.open_source_translate_api import _combine_translation_chunks, \
+    OpenSourceTranslateAPI
+
+
+class MyTestCase(unittest.TestCase):
+    def setUp(self):
+        self.FROM_LANGUAGE = "en"
+        self.TO_LANGUAGES = ["af"]
+        self.CHUNK_SIZE = 100
+        self.translations = [
+            "The quick brown fox jumps over the lazy dog.",
+            "Sphinx of black quartz, judge my vow."
+        ]
+        self.column_name = "translations"
+        self.batch = pd.DataFrame({self.column_name: self.translations})
+
+    def test_chunks_combined_correctly(self):
+        translations = [
+            "The quick brown fox", " jumps over", " the lazy dog.",
+            "Sphinx of black quartz, ", "judge my vow."
+        ]
+        lengths = [3, 2]
+        result = _combine_translation_chunks(translations, lengths)
+        self.assertEqual("The quick brown fox jumps over the lazy dog.", result[0])
+        self.assertEqual("Sphinx of black quartz, judge my vow.", result[1])
+
+    def test_translate_text(self):
+        api = MockOpenSourceApi(self.FROM_LANGUAGE, self.TO_LANGUAGES, self.CHUNK_SIZE)
+
+        results = api.translate(self.batch, [self.column_name])
+
+        for to_language in self.TO_LANGUAGES:
+            rows = results[to_language].get(f'{self.FROM_LANGUAGE}-{self.column_name}')
+            for index, row in enumerate(rows):
+                self.assertEqual(self.translations[index], row)
+
+    def test_multiple_languages(self):
+        to_languages = ["af", "zh"]
+        api = MockOpenSourceApi(self.FROM_LANGUAGE, to_languages, self.CHUNK_SIZE)
+
+        results = api.translate(self.batch, [self.column_name])
+
+        for to_language in to_languages:
+            rows = results[to_language].get(f'{self.FROM_LANGUAGE}-{self.column_name}')
+            for index, row in enumerate(rows):
+                self.assertEqual(self.translations[index], row)
+
+    def test_multiple_chunks(self):
+        api = MockOpenSourceApi(self.FROM_LANGUAGE, self.TO_LANGUAGES, 25)
+
+        results = api.translate(self.batch, [self.column_name])
+
+        for to_language in self.TO_LANGUAGES:
+            rows = results[to_language].get(f'{self.FROM_LANGUAGE}-{self.column_name}')
+            for index, row in enumerate(rows):
+                self.assertEqual(self.translations[index], row)
+
+class MockOpenSourceApi(OpenSourceTranslateAPI):
+    def __init__(self, from_language: str, to_languages: List[str], chunk_size: int):
+        super().__init__(from_language, to_languages, chunk_size)
+
+    def _translate(self, batch: List[str], to_language: str) -> List[str]:
+        return batch
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Notes:
* When running translations in the advanced router, azure is processing 32~ million characters where the total dataset size is 39~ million characters. This is due to the limit size of open source models. 
* Currently Open source had limits with the size of translations it can take. Opus has a limit of 512 characters. By chunking batches, we are able to overcome length challenges in opus.

### Testing:
* Wrote some unit tests to test the logic of chunking batches and recombining the translations